### PR TITLE
Add path rewriting

### DIFF
--- a/server/Controllers/StreamController.ts
+++ b/server/Controllers/StreamController.ts
@@ -21,12 +21,17 @@ export class StreamController implements IController {
   }
 
   streamMedia: RequestHandler = async (req, res) => {
-    const { mediaLocation } = AppContext.get(AppContext.WellKnown.Config);
+    const { mediaLocation, pathRewrites } = AppContext.get(
+      AppContext.WellKnown.Config
+    );
     const videoId = req.params.video.replace('.mp4', '');
     const userId = req.user?._id ?? undefined;
     const video = await this._mediaManager.findById(videoId, userId);
     const vDir = video.path ? video.path : mediaLocation;
-    const vPath = path.join(vDir, video.filename);
+    const mediaPath = Object.keys(pathRewrites).includes(vDir)
+      ? pathRewrites[vDir]
+      : vDir;
+    const vPath = path.join(mediaPath, video.filename);
 
     const stat = fs.statSync(vPath);
     const fileSize = stat.size;

--- a/server/Utilities/ConfigUtil.ts
+++ b/server/Utilities/ConfigUtil.ts
@@ -23,6 +23,9 @@ export class Configuration {
   session: {
     secret: string;
   };
+  pathRewrites: {
+    [documentPath: string]: string;
+  };
 
   public static fromJson(data: string) {
     const obj = new Configuration();
@@ -38,7 +41,8 @@ export class Configuration {
       session: this.session,
       server: this.server,
       mongo: this.mongo,
-      allowUnsafeFileAccess: this.allowUnsafeFileAccess
+      allowUnsafeFileAccess: this.allowUnsafeFileAccess,
+      pathRewrites: this.pathRewrites
     });
   }
 
@@ -55,6 +59,7 @@ export class Configuration {
     };
     this.name = data.name;
     this.port = data.port;
+    this.pathRewrites = data.pathRewrites;
 
     if (data.server) {
       this.server = data.server;
@@ -82,7 +87,8 @@ export class Configuration {
       secret: _.isString
     }),
     name: _.isString,
-    port: _.isInteger
+    port: _.isInteger,
+    pathRewrites: (value) => _.values(value).every(_.isString)
   });
 }
 


### PR DESCRIPTION
Adding path rewriting. This is to allow a user to rewrite the location of media. The primary use of this is to allow database portability without having to modify database documents directly. For most uses, the configuration object can be left empty.